### PR TITLE
Fix duplicate slug handling logic for categories, tags and blog posts

### DIFF
--- a/src/Fan.Blog/Helpers/BlogUtil.cs
+++ b/src/Fan.Blog/Helpers/BlogUtil.cs
@@ -1,9 +1,7 @@
 ﻿using AutoMapper;
 using Fan.Blog.Models;
 using Fan.Helpers;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Fan.Blog.Helpers
 {
@@ -18,11 +16,11 @@ namespace Fan.Blog.Helpers
         /// <remarks>
         /// This method makes sure the result slug
         /// - not to exceed max len;
-        /// - if <see cref="Util.FormatSlug(string)"/> returns empty string, it generates a random one;
+        /// - if <see cref="Util.Slugify(string)"/> returns empty string, it generates a random one;
         /// - a unique value if its a duplicate with existings slugs;
         /// - if '#' char is present, I swap it to 's'
         /// </remarks>
-        public static string FormatTaxonomySlug(string title, int maxlen, IEnumerable<string> existingSlugs = null)
+        public static string SlugifyTaxonomy(string title, int maxlen, IEnumerable<string> existingSlugs = null)
         {
             // if user input exceeds max len, we trim
             if (title.Length > maxlen)
@@ -30,26 +28,14 @@ namespace Fan.Blog.Helpers
                 title = title.Substring(0, maxlen);
             }
 
-            title = title.Replace('#', 's'); // preserve # as s before format to slug
-            var slug = Util.FormatSlug(title); // remove/replace odd char, lower case etc
+            // preserve # as s before format to slug
+            title = title.Replace('#', 's');
 
-            // slug from title could be empty, e.g. the title is in Chinese
-            // then we generate a random string of 6 chars
-            if (slug.IsNullOrEmpty())
-            {
-                slug = Util.RandomString(6);
-            }
+            // make slug
+            var slug = Util.Slugify(title, randomCharCountOnEmpty: 6);
 
             // make sure slug is unique
-            int i = 2;
-            if (existingSlugs != null)
-            {
-                while (existingSlugs.Contains(slug))
-                {
-                    slug = $"{slug}-{i}";
-                    i++;
-                }
-            }
+            slug = Util.UniquefySlug(slug, existingSlugs);
 
             return slug;
         }

--- a/src/Fan.Blog/Services/CategoryService.cs
+++ b/src/Fan.Blog/Services/CategoryService.cs
@@ -149,7 +149,7 @@ namespace Fan.Blog.Services
             var category = new Category
             {
                 Title = title,
-                Slug = BlogUtil.FormatTaxonomySlug(title, SLUG_MAXLEN, allCats.Select(c => c.Slug)),
+                Slug = BlogUtil.SlugifyTaxonomy(title, SLUG_MAXLEN, allCats.Select(c => c.Slug)),
                 Description = Util.CleanHtml(description),
                 Count = 0,
             };
@@ -192,7 +192,7 @@ namespace Fan.Blog.Services
             // prep slug, description and count
             var entity = await _catRepo.GetAsync(category.Id);
             entity.Title = category.Title; // assign new title
-            entity.Slug = BlogUtil.FormatTaxonomySlug(category.Title, SLUG_MAXLEN, allCats.Select(c => c.Slug)); // slug is based on title
+            entity.Slug = BlogUtil.SlugifyTaxonomy(category.Title, SLUG_MAXLEN, allCats.Select(c => c.Slug)); // slug is based on title
             entity.Description = Util.CleanHtml(category.Description);
             entity.Count = category.Count;
 

--- a/src/Fan.Blog/Services/ImageService.cs
+++ b/src/Fan.Blog/Services/ImageService.cs
@@ -320,7 +320,7 @@ namespace Fan.Blog.Services
             }
 
             // slug file name
-            var slug = Util.FormatSlug(fileNameWithoutExt);
+            var slug = Util.Slugify(fileNameWithoutExt);
             if (slug.IsNullOrEmpty()) // slug may end up empty
             {
                 slug = Util.RandomString(6);
@@ -345,7 +345,7 @@ namespace Fan.Blog.Services
         /// <returns></returns>
         private async Task<string> GetUniqueFileNameAsync(string fileNameSlugged, DateTimeOffset uploadedOn)
         {
-            int i = 1;
+            int i = 2;
             while (await _mediaSvc.ExistsAsync(m => m.AppType == EAppType.Blog &&
                                                     m.UploadedOn.Year == uploadedOn.Year &&
                                                     m.UploadedOn.Month == uploadedOn.Month &&
@@ -353,7 +353,7 @@ namespace Fan.Blog.Services
             {
                 var lookUp = ".";
                 var replace = $"-{i}.";
-                if (i > 1)
+                if (i > 2)
                 {
                     int j = i - 1;
                     lookUp = $"-{j}.";

--- a/src/Fan.Blog/Services/PageService.cs
+++ b/src/Fan.Blog/Services/PageService.cs
@@ -231,7 +231,7 @@ namespace Fan.Blog.Services
             if (input.Length > TITLE_MAXLEN)
                 input = input.Substring(0, TITLE_MAXLEN);
 
-            var slug = Util.FormatSlug(input); // remove/replace odd char, lower case etc
+            var slug = Util.Slugify(input); // remove/replace odd char, lower case etc
 
             // slug from title could be empty, e.g. the title is in Chinese
             // then we generate a random string of 6 chars

--- a/src/Fan.Blog/Services/TagService.cs
+++ b/src/Fan.Blog/Services/TagService.cs
@@ -152,7 +152,7 @@ namespace Fan.Blog.Services
             }
 
             // prep slug, description and count
-            tag.Slug = BlogUtil.FormatTaxonomySlug(tag.Title, SLUG_MAXLEN, allTags.Select(c => c.Slug)); // slug is based on title
+            tag.Slug = BlogUtil.SlugifyTaxonomy(tag.Title, SLUG_MAXLEN, allTags.Select(c => c.Slug)); // slug is based on title
             tag.Description = Util.CleanHtml(tag.Description);
             tag.Count = tag.Count;
 
@@ -194,7 +194,7 @@ namespace Fan.Blog.Services
             // prep slug, description and count
             var entity = await _tagRepo.GetAsync(tag.Id);
             entity.Title = tag.Title; // assign new title
-            entity.Slug = BlogUtil.FormatTaxonomySlug(tag.Title, SLUG_MAXLEN, allTags.Select(c => c.Slug)); // slug is based on title
+            entity.Slug = BlogUtil.SlugifyTaxonomy(tag.Title, SLUG_MAXLEN, allTags.Select(c => c.Slug)); // slug is based on title
             entity.Description = Util.CleanHtml(tag.Description);
             entity.Count = tag.Count;
 

--- a/test/Fan.Blog.IntegrationTests/ImageServiceTest.cs
+++ b/test/Fan.Blog.IntegrationTests/ImageServiceTest.cs
@@ -57,7 +57,7 @@ namespace Fan.Blog.IntegrationTests
             Assert.Equal(contentType, media.ContentType);
 
             // with a unique name
-            Assert.Equal("fanray-logo-1.png", media.FileName);
+            Assert.Equal("fanray-logo-2.png", media.FileName);
 
             // 0 resized, only orig was saved
             Assert.Equal(0, media.ResizeCount);

--- a/test/Fan.Blog.IntegrationTests/MetaWeblogServiceTest.cs
+++ b/test/Fan.Blog.IntegrationTests/MetaWeblogServiceTest.cs
@@ -239,7 +239,7 @@ namespace Fan.Blog.IntegrationTests
             var uploadedOn = DateTimeOffset.UtcNow;
             var year = uploadedOn.Year.ToString();
             var month = uploadedOn.Month.ToString("d2");
-            var expectedUrl = $"{STORAGE_ENDPOINT}/media/blog/{year}/{month}/fanray-logo-1.png";
+            var expectedUrl = $"{STORAGE_ENDPOINT}/media/blog/{year}/{month}/fanray-logo-2.png";
             Assert.Equal(expectedUrl, mediaInfo.Url);
 
             // and storage provider is called only once since it's a tiny image

--- a/test/Fan.Blog.UnitTests/Helpers/BlogUtilTest.cs
+++ b/test/Fan.Blog.UnitTests/Helpers/BlogUtilTest.cs
@@ -1,4 +1,5 @@
 ﻿using Fan.Blog.Helpers;
+using Fan.Blog.Services;
 using System.Collections.Generic;
 using Xunit;
 
@@ -7,19 +8,61 @@ namespace Fan.Blog.UnitTests.Helpers
     public class BlogUtilTest
     {
         /// <summary>
-        /// Test <see cref="Util.FormatTaxonomySlug(string, IEnumerable{string})"/> for
-        /// long, duplicate user inputs.
+        /// When user inputs a long title, it will result a long slug, <see cref="BlogUtil.SlugifyTaxonomy(string, int, IEnumerable{string})"/>
+        /// will truncate the slug and keep <see cref="CategoryService.SLUG_MAXLEN"/> or <see cref="TagService.SLUG_MAXLEN"/>
+        /// number of characters.
         /// </summary>
         /// <param name="input"></param>
         /// <param name="expected"></param>
         /// <param name="existingSlugs"></param>
-        [Theory]
-        [InlineData("c#", "cs")]
-        [InlineData("this is a really long category title", "this-is-a-really-long-ca")]
-        [InlineData("cat1", "cat1-2", new string[] { "cat1" })]
-        public void FormatTaxonomySlug_Test(string input, string expected, IEnumerable<string> existingSlugs = null)
+        [Fact]
+        public void SlugifyTaxonomy_trucates_long_slug_and_keeps_only_24_chars()
         {
-            Assert.Equal(expected, BlogUtil.FormatTaxonomySlug(input, 24, existingSlugs));
+            var expected = "this-is-a-really-long-ca";
+            var actual = BlogUtil.SlugifyTaxonomy("this is a really long category title", CategoryService.SLUG_MAXLEN);
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
+        /// When inputted title has "#" it will be replaced by letter "s".
+        /// </summary>
+        [Fact]
+        public void SlugifyTaxonomy_replaces_hashtag_with_letter_s()
+        {
+            var expected = "cs";
+            var actual = BlogUtil.SlugifyTaxonomy("c#", CategoryService.SLUG_MAXLEN);
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
+        /// Not everything could be slugified, for example given a title in Chinese,
+        /// this method will return a 6-char randon string.
+        /// </summary>
+        [Fact]
+        public void SlugifyTaxonomy_produces_8chars_string_when_input_is_non_english()
+        {
+            var actual = BlogUtil.SlugifyTaxonomy("你好", CategoryService.SLUG_MAXLEN);
+            Assert.True(actual.Length == 6);
+        }
+
+        /// <summary>
+        /// When user give a title to category or tag, their according service will generate a slug
+        /// based on the title. So the title inputted may not exist but the logic to generate the
+        /// slug could still output a slug that exists, for example "c#" and "cs" are two titles that
+        /// will generate "cs" slug.  Therefore this util method make the slug unique by appending a
+        /// counter to it, the counter starts with 2.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="expected"></param>
+        /// <param name="existing"></param>
+        [Theory]
+        [InlineData("c#", "cs-2", new string[] { "cs" })]
+        [InlineData("cs", "cs-2", new string[] { "cs" })]
+        [InlineData("cat", "cat-2", new string[] { "cat" })]
+        [InlineData("cat-2", "cat-3", new string[] { "cat-2" })]
+        public void SlugifyTaxonomy_returns_unique_slug_by_append_counter_to_duplicate(string input, string expected, IEnumerable<string> existing = null)
+        {
+            Assert.Equal(expected, BlogUtil.SlugifyTaxonomy(input, CategoryService.SLUG_MAXLEN, existing));
         }
     }
 }

--- a/test/Fan.UnitTests/Helpers/UtilTest.cs
+++ b/test/Fan.UnitTests/Helpers/UtilTest.cs
@@ -10,7 +10,7 @@ namespace Fan.UnitTests.Helpers
     public class UtilTest
     {
         /// <summary>
-        /// Test for <see cref="Util.FormatSlug(string)"/>.
+        /// Test for <see cref="Util.Slugify(string)"/>.
         /// </summary>
         [Theory]
         [InlineData("c#", "c")]
@@ -20,9 +20,9 @@ namespace Fan.UnitTests.Helpers
         [InlineData("1.1-1_1_.-", "1-1-1-1")]
         [InlineData("你好。", "")]
         [InlineData("<script>A post title</script>", "scripta-post-title-script")]
-        public void FormatSlug_Test(string slug, string expected)
+        public void Slugify_turns_a_string_into_url_friendly_slug(string title, string expected)
         {
-            Assert.Equal(expected, Util.FormatSlug(slug));
+            Assert.Equal(expected, Util.Slugify(title));
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Fan.UnitTests.Helpers
         [InlineData("<p>A body more than 5 words.</p>", "A body more than 5 words.", 6)]
         [InlineData("<p>A body more than 5 words.</p>", "A body more than 5…", 5)]
         [InlineData("<p></p>", "", 55)]
-        public void GetExcerpt_Test(string body, string expected, int wordLimit)
+        public void GetExcerpt_returns_a_string_excerpt_from_a_given_html(string body, string expected, int wordLimit)
         {
             Assert.Equal(expected, Util.GetExcerpt(body, wordLimit));
         }
@@ -75,11 +75,11 @@ namespace Fan.UnitTests.Helpers
         [Fact]
         public void DateTimeOffset_should_be_used_instead_of_DateTime()
         {
-            Assert.Equal("now", DateTimeOffset.UtcNow.Humanize()); 
-            Assert.Equal("now", DateTimeOffset.Now.Humanize()); 
+            Assert.Equal("now", DateTimeOffset.UtcNow.Humanize());
+            Assert.Equal("now", DateTimeOffset.Now.Humanize());
 
             // OK
-            Assert.Equal("now", DateTime.UtcNow.Humanize()); 
+            Assert.Equal("now", DateTime.UtcNow.Humanize());
             // Ambiguous
             // Fails on IANA time zone machine it outputs "now" 
             // but on my local windows it outputs "7 hours ago"
@@ -90,7 +90,7 @@ namespace Fan.UnitTests.Helpers
         [InlineData("你好。", "你好。")]
         [InlineData("c#", "c#")]
         [InlineData("<h1>", "&lt;h1&gt;")]
-        public void WebUtility_HtmlEncode_Test(string input, string expected)
+        public void WebUtility_HtmlEncode_escapes_special_chars(string input, string expected)
         {
             Assert.Equal(expected, WebUtility.HtmlEncode(input));
         }


### PR DESCRIPTION
I fixed logic for handling duplicate slug for categories, tags and blog posts.